### PR TITLE
Adds descriptive text to Profile and adds backdrop to sidebar

### DIFF
--- a/music-quiz/src/presenters/sidebarPresenter.js
+++ b/music-quiz/src/presenters/sidebarPresenter.js
@@ -62,6 +62,7 @@ export default function SidebarPresenter(props) {
     } else {
       props.model.setCurrentChallenge(requestId);
       navigate("/play");
+      expand();
     }
   }
 
@@ -105,7 +106,7 @@ export default function SidebarPresenter(props) {
         show={expanded}
         onHide={expand}
         scroll={true}
-        backdrop={false}
+        backdrop={true}
         style={{ width: "600px" }}
       >
         <Offcanvas.Header closeButton>
@@ -121,6 +122,7 @@ export default function SidebarPresenter(props) {
                 color: "grey",
                 textDecoration: "none",
               }}
+              onClick={() => expand()}
             >
               <Badge pill>
                 <Image src={plus} height="9px" />
@@ -138,6 +140,7 @@ export default function SidebarPresenter(props) {
             playlist={playlist}
             choosePlaylist={choosePlaylist}
             challenge={challenge}
+            expand={expand}
           />
           <div style={{ position: "sticky", bottom: "0px", left: "0px" }}>
             <PendingView

--- a/music-quiz/src/presenters/userProfilePresenter.js
+++ b/music-quiz/src/presenters/userProfilePresenter.js
@@ -4,6 +4,8 @@ import ShowPlaylistView from "../views/showPlaylistView";
 import UserInfoView from "../views/userInfoView";
 import CreatePlaylistButtonView from "../views/createPlaylistButtonView";
 import ReactStars from "react-rating-stars-component";
+import friendNotes from "../images/two_shades_friend_notes.png";
+import Image from "react-bootstrap/Image";
 
 export default function UserProfilePresenter(props) {
   const [playlists, updatePlaylists] = useState(props.model.playlists);
@@ -90,6 +92,13 @@ export default function UserProfilePresenter(props) {
   return (
     <div>
       <UserInfoView email={props.model.email} username={props.model.username} />
+      <div style={{ display: "flex", marginBottom: "10px" }}>
+        <Image src={friendNotes} width="40px" />
+        <p style={{ paddingTop: "5px", margin: "0px" }}>
+          Press the button in the left upper corner too see your friends and
+          challenge them.
+        </p>
+      </div>
       <ShowPlaylistView
         playlists={playlists}
         averageRating={averageRating}

--- a/music-quiz/src/style/index.css
+++ b/music-quiz/src/style/index.css
@@ -18,3 +18,7 @@ html *
 a.navbar-hover:hover {
     color: lightgrey !important;
 }
+
+a {
+    text-decoration: none !important;
+}

--- a/music-quiz/src/views/friendsView.js
+++ b/music-quiz/src/views/friendsView.js
@@ -50,7 +50,14 @@ export default function FriendsView(props) {
             >
               <div>
                 <Image src={img} width="50" />
-                <Link to={`/friend?id=${friend.id}`}>{friend.username}</Link>
+                <Link
+                  to={`/friend?id=${friend.id}`}
+                  onClick={() => {
+                    props.expand();
+                  }}
+                >
+                  {friend.username}
+                </Link>
               </div>
               <Button
                 onClick={(e) => props.togglePopup(friend)}


### PR DESCRIPTION
This PR resolves #73.

- A backdrop is added to the sidebar to enable a user to close the sidebar by clicking in the area beside it
- When we click the button "Add friends", the sidebar is closed
- When we click accept a challenge, the sidebar is closed
- On user profile page, a descriptive text is added directing the user to the sidebar if they want to add friends, see image below:
<img width="542" alt="image" src="https://user-images.githubusercontent.com/59956393/208100316-a0784649-0e34-43d7-87f8-688a504c782f.png">
