### PR TITLE
Corrects redirection issues and fixes backgound image

### DIFF
--- a/music-quiz/src/ReactRoot.js
+++ b/music-quiz/src/ReactRoot.js
@@ -40,7 +40,7 @@ function ReactRoot() {
       style={{
         backgroundImage: `url(${backgroundImage})`,
         width: "100vw",
-        height: "100vh",
+        minHeight: "100vh",
         backgroundRepeat: "no-repeat",
         backgroundSize: "cover",
       }}

--- a/music-quiz/src/presenters/loginPresenter.js
+++ b/music-quiz/src/presenters/loginPresenter.js
@@ -65,7 +65,7 @@ export default function Login(props) {
         style={{ minHeight: "75vh" }}
       >
         {currentUser ? (
-          <Navigate replace to="/play" />
+          <Navigate replace to="/profile" />
         ) : (
           <LoginView
             error={loginPromiseState.error}


### PR DESCRIPTION
Closes #92, closes #98

- Every page should now redirect the user to /login when logging out
- When logging in, the user should now be redirected to /profile instead of /play
- I realised that the background got cut off on the profile page when scrolling is needed, see image below. This should now be fixed.

<img width="220" alt="image" src="https://user-images.githubusercontent.com/59956393/208309185-eae1504d-ad3e-49a3-ba1a-68f7f41858c5.png">
